### PR TITLE
bugs(variablesHtml.py | general.html | crearGeneralHtml.py): arreglado error de estructura HTML en Python

### DIFF
--- a/docs/general.html
+++ b/docs/general.html
@@ -1,263 +1,283 @@
 <!Doctype html>
 <html LANG="es">
-    <head>
-        <meta charset="utf-8">
-        <meta name="description" content="Alquila la bici que mas te guste al mejor precio">
-        <meta name="author" content="Adrián López">
-        <meta name="date" content="27/11/2020">
-        <meta name="last-modified" content="04 de Diciembre de 2022">
-        <meta name="keyword" content="Bicis, Alquilar bicis, Monbike, Mallorca bicis">
-        <link rel="StyleSheet" href="style.css">
-        
-        <!-- LOGO MonBike-->
-        <link rel="shortcut icon" href="img/monbike_bici_logo.png">
+  <head>
+    <meta charset="utf-8">
+    <meta name="description" content="Alquila la bici que mas te guste al mejor precio">
+    <meta name="author" content="Adrián López">
+    <meta name="date" content="27/11/2020">
+    <meta name="last-modified" content="04 de Diciembre de 2022">
+    <meta name="keyword" content="Bicis, Alquilar bicis, Monbike, Mallorca bicis">
+    <link rel="StyleSheet" href="style.css">
+    
+    <!-- LOGO MonBike-->
+    <link rel="shortcut icon" href="img/monbike_bici_logo.png">
 
-        <!-- Titulo MonBike -->
-        <title>MonBike</title>
-    </head>
-    <body>
-<h1 class="titulo_general"> Estas son todas las bicis que tenemos actualmente:</h1>
-<div class="general_bicis">
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1990093/k$af39175e357bc14813feaba87898425d/sq/bicicleta-de-carretera-carbono-ultegra-van-rysel-edr-cf-negro.jpg?f=720x720' class='img_varias_bicis'>
-<h2>Bicicleta de carretera carbono ultegra Van Rysel EDR CF negro</h2>
-<p>
- 1 Día   - 78€ <br>
- 5 Días  - 78€ <br>
- 10 Días  - 78€ <br>
-  15 Días - 78€ <br>
-  30 Días - 78€ </p> <br>
-<br>
-<a href='6384ea156b1b912573be8353.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1614862/k$e5a126560124dfbf58f788b502fc8144/sq/bicicleta-de-carretera-aluminio-freno-de-disco-triban-rc-120-azul-naranja.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta de carretera aluminio freno de disco Triban RC 120 azul naranja</h2>
-<p>
- 1 Día   - 30€ <br>
- 5 Días  - 30€ <br>
- 10 Días  - 30€ <br>
-  15 Días - 30€ <br>
-  30 Días - 30€ </p> <br>
-<br>
-<a href='6384fabd6b1b912573be8359.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1829873/k$f72a53df40740405e134df0b2a036b63/sq/bicicleta-de-carretera-aluminio-shimano-105-11v-van-rysel-edr-af-negro.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta de carretera aluminio Shimano 105 11V Van Rysel EDR AF negro</h2>
-<p>
- 1 Día   - 56€ <br>
- 5 Días  - 56€ <br>
- 10 Días  - 56€ <br>
-  15 Días - 56€ <br>
-  30 Días - 56€ </p> <br>
-<br>
-<a href='6384fc136b1b912573be835a.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p2111186/k$c491cbf765c4f88d1fc91e4ca24e4e5f/sq/bicicleta-de-carretera-aluminio-con-freno-de-disco-sora-9v-triban-rc-500-negra.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta de carretera aluminio con freno de disco Sora 9V Triban RC 500 negra</h2>
-<p>
- 1 Día   - 36€ <br>
- 5 Días  - 36€ <br>
- 10 Días  - 36€ <br>
-  15 Días - 36€ <br>
-  30 Días - 36€ </p> <br>
-<br>
-<a href='6384fd736b1b912573be835b.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1832242/k$7295a00ca810692e393ce80218876aa6/sq/bicicleta-de-carretera-aluminio-manillar-plano-freno-de-disco-triban-rc-120-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta de carretera aluminio manillar plano freno de disco Triban RC 120 azul</h2>
-<p>
- 1 Día   - 28€ <br>
- 5 Días  - 28€ <br>
- 10 Días  - 28€ <br>
-  15 Días - 28€ <br>
-  30 Días - 28€ </p> <br>
-<br>
-<a href='6384fe756b1b912573be835c.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/dpv-c353202103-01_1001.jpg' class='img_varias_bicis'>
-<h2>Bicicleta MTB Deporvillage GR900 29</h2>
-<p>
- 1 Día   - 20€ <br>
- 5 Días  - 20€ <br>
- 10 Días  - 20€ <br>
-  15 Días - 20€ <br>
-  30 Días - 20€ </p> <br>
-<br>
-<a href='6384ff576b1b912573be835d.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/fcd-d641013010-c_001.jpg' class='img_varias_bicis'>
-<h2>Bicicleta MTB Focus Jam</h2>
-<p>
- 1 Día   - 60€ <br>
- 5 Días  - 60€ <br>
- 10 Días  - 60€ <br>
-  15 Días - 60€ <br>
-  30 Días - 60€ </p> <br>
-<br>
-<a href='638501c66b1b912573be835e.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/dpv-c353202103-02_1001.jpg' class='img_varias_bicis'>
-<h2>Bicicleta MTB Deporvillage GR900 29</h2>
-<p>
- 1 Día   - 17€ <br>
- 5 Días  - 17€ <br>
- 10 Días  - 17€ <br>
-  15 Días - 17€ <br>
-  30 Días - 17€ </p> <br>
-<br>
-<a href='638503506b1b912573be835f.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://cdn.deporvillage.com/cdn-cgi/image/f=auto,q=75,fit=contain,background=white/product/umt-2611-71_001_1.jpg' class='img_varias_bicis'>
-<h2>Bicicleta MTB Umit 4 Motion</h2>
-<p>
- 1 Día   - 12€ <br>
- 5 Días  - 12€ <br>
- 10 Días  - 12€ <br>
-  15 Días - 12€ <br>
-  30 Días - 12€ </p> <br>
-<br>
-<a href='6385081c6b1b912573be8361.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/me-51780-c_001.jpg' class='img_varias_bicis'>
-<h2>Bicicleta MTB Merida Big Nine 300</h2>
-<p>
- 1 Día   - 31€ <br>
- 5 Días  - 31€ <br>
- 10 Días  - 31€ <br>
-  15 Días - 31€ <br>
-  30 Días - 31€ </p> <br>
-<br>
-<a href='638508996b1b912573be8362.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/m6191673/k$3ac858333488e0f532c39e672c446e75/sq/bicicleta-electrica-de-ciudad-ncm-c5.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta eléctrica de ciudad NCM C5</h2>
-<p>
- 1 Día   - 56€ <br>
- 5 Días  - 56€ <br>
- 10 Días  - 56€ <br>
-  15 Días - 56€ <br>
-  30 Días - 56€ </p> <br>
-<br>
-<a href='63850b7f6b1b912573be8363.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p2323533/k$fd94592e41e52e8240d17a17e51fe1ba/sq/bicicleta-electrica-trekking-cuadro-bajo-riverside-100-e-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta eléctrica trekking cuadro bajo Riverside 100 E azul</h2>
-<p>
- 1 Día   - 72€ <br>
- 5 Días  - 72€ <br>
- 10 Días  - 72€ <br>
-  15 Días - 72€ <br>
-  30 Días - 72€ </p> <br>
-<br>
-<a href='63850c2b6b1b912573be8364.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1638738/k$fd2bacecab66a5bd4a0d4a3fbd5359d6/sq/bicicleta-electrica-de-montaa-275-rockrider-ebike-st-900-gris.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Rockrider Ebike ST 900 gris</h2>
-<p>
- 1 Día   - 100€ <br>
- 5 Días  - 100€ <br>
- 10 Días  - 100€ <br>
-  15 Días - 100€ <br>
-  30 Días - 100€ </p> <br>
-<br>
-<a href='63850f366b1b912573be8365.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p1958112/k$a37e0dd7e3d9bbd6f926e3b6d7a91d09/sq/bicicleta-electrica-gravel-de-carbono-windee-negra.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta eléctrica gravel de carbono Windee negra</h2>
-<p>
- 1 Día   - 100€ <br>
- 5 Días  - 100€ <br>
- 10 Días  - 100€ <br>
-  15 Días - 100€ <br>
-  30 Días - 100€ </p> <br>
-<br>
-<a href='638510436b1b912573be8366.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/m5641940/k$9bc5d7e36c065ce82584903381b6b936/sq/bicicleta-electrica-de-montaa-ncm-moscow.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta eléctrica de montaña NCM Moscow</h2>
-<p>
- 1 Día   - 70€ <br>
- 5 Días  - 70€ <br>
- 10 Días  - 70€ <br>
-  15 Días - 70€ <br>
-  30 Días - 70€ </p> <br>
-<br>
-<a href='638511156b1b912573be8367.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p2288175/k$0bb7564beb0379fa4e8b9f41d727da6f/sq/bicicleta-urbana-clasica-elops-520-cuadro-bajo-28-pulgadas-6-v-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta urbana clásica Elops 520 cuadro bajo 28 pulgadas 6 V azul</h2>
-<p>
- 1 Día   - 32€ <br>
- 5 Días  - 32€ <br>
- 10 Días  - 32€ <br>
-  15 Días - 32€ <br>
-  30 Días - 32€ </p> <br>
-<br>
-<a href='638512916b1b912573be8368.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p2215480/k$256efddc38e0e25002047e8cbd47b22e/sq/bicicleta-urbana-cuadro-alto-elops-540-azul-petroleo.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta urbana cuadro alto Elops 540 azul petróleo</h2>
-<p>
- 1 Día   - 55€ <br>
- 5 Días  - 55€ <br>
- 10 Días  - 55€ <br>
-  15 Días - 55€ <br>
-  30 Días - 55€ </p> <br>
-<br>
-<a href='63852f6725096331c621b254.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/p2288260/k$9e8ec5fdb2caecee5f0cd29ff6ae03cb/sq/bicicleta-urbana-clasica-cuadro-bajo-28-pulgadas-elops-120-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta urbana clásica cuadro bajo 28 pulgadas Elops 120 azul</h2>
-<p>
- 1 Día   - 15€ <br>
- 5 Días  - 15€ <br>
- 10 Días  - 15€ <br>
-  15 Días - 15€ <br>
-  30 Días - 15€ </p> <br>
-<br>
-<a href='6385317c25096331c621b255.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/m5419555/k$1a25a4a575387a8eef87a6174396db0a/sq/bicicleta-paseo-city-classic-26-aluminio-shimano-18v.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta Paseo City Classic 26</h2>
-<p>
- 1 Día   - 26€ <br>
- 5 Días  - 26€ <br>
- 10 Días  - 26€ <br>
-  15 Días - 26€ <br>
-  30 Días - 26€ </p> <br>
-<br>
-<a href='6385328525096331c621b256.html'>ALQUILAR</a>
-</div>
-<div class="general_una_bici">
-<img src='https://contents.mediadecathlon.com/m5419674/k$a70f29effa74ced3f5e632bca44df671/sq/bicicleta-trekking-paseo-shimano-hybrid-28-alu-18v-susp-delant.jpg?format=auto&f=800x0' class='img_varias_bicis'>
-<h2>Bicicleta Trekking</h2>
-<p>
- 1 Día   - 14€ <br>
- 5 Días  - 14€ <br>
- 10 Días  - 14€ <br>
-  15 Días - 14€ <br>
-  30 Días - 14€ </p> <br>
-<br>
-<a href='638534fa25096331c621b257.html'>ALQUILAR</a>
-</div>
-</div>
-    </body>
+    <!-- Titulo MonBike -->
+    <title>MonBike</title>
+  </head>
+  <body>
+    <h1 class="titulo_general"> Estas son todas las bicis que tenemos actualmente:</h1>
+    <div class="general_bicis">
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1990093/k$af39175e357bc14813feaba87898425d/sq/bicicleta-de-carretera-carbono-ultegra-van-rysel-edr-cf-negro.jpg?f=720x720' class='img_varias_bicis'>
+        <h2>Bicicleta de carretera carbono ultegra Van Rysel EDR CF negro</h2>
+        <p>
+          1 Día   - 78€ <br>
+          5 Días  - 78€ <br>
+          10 Días  - 78€ <br>
+          15 Días - 78€ <br>
+          30 Días - 78€
+        </p>
+        <br>
+        <a href='6384ea156b1b912573be8353.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1614862/k$e5a126560124dfbf58f788b502fc8144/sq/bicicleta-de-carretera-aluminio-freno-de-disco-triban-rc-120-azul-naranja.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta de carretera aluminio freno de disco Triban RC 120 azul naranja</h2>
+        <p>
+          1 Día   - 30€ <br>
+          5 Días  - 30€ <br>
+          10 Días  - 30€ <br>
+          15 Días - 30€ <br>
+          30 Días - 30€
+        </p>
+        <br>
+        <a href='6384fabd6b1b912573be8359.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1829873/k$f72a53df40740405e134df0b2a036b63/sq/bicicleta-de-carretera-aluminio-shimano-105-11v-van-rysel-edr-af-negro.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta de carretera aluminio Shimano 105 11V Van Rysel EDR AF negro</h2>
+        <p>
+          1 Día   - 56€ <br>
+          5 Días  - 56€ <br>
+          10 Días  - 56€ <br>
+          15 Días - 56€ <br>
+          30 Días - 56€
+        </p>
+        <br>
+        <a href='6384fc136b1b912573be835a.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p2111186/k$c491cbf765c4f88d1fc91e4ca24e4e5f/sq/bicicleta-de-carretera-aluminio-con-freno-de-disco-sora-9v-triban-rc-500-negra.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta de carretera aluminio con freno de disco Sora 9V Triban RC 500 negra</h2>
+        <p>
+          1 Día   - 36€ <br>
+          5 Días  - 36€ <br>
+          10 Días  - 36€ <br>
+          15 Días - 36€ <br>
+          30 Días - 36€
+        </p>
+        <br>
+        <a href='6384fd736b1b912573be835b.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1832242/k$7295a00ca810692e393ce80218876aa6/sq/bicicleta-de-carretera-aluminio-manillar-plano-freno-de-disco-triban-rc-120-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta de carretera aluminio manillar plano freno de disco Triban RC 120 azul</h2>
+        <p>
+          1 Día   - 28€ <br>
+          5 Días  - 28€ <br>
+          10 Días  - 28€ <br>
+          15 Días - 28€ <br>
+          30 Días - 28€
+        </p>
+        <br>
+        <a href='6384fe756b1b912573be835c.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/dpv-c353202103-01_1001.jpg' class='img_varias_bicis'>
+        <h2>Bicicleta MTB Deporvillage GR900 29</h2>
+        <p>
+          1 Día   - 20€ <br>
+          5 Días  - 20€ <br>
+          10 Días  - 20€ <br>
+          15 Días - 20€ <br>
+          30 Días - 20€
+        </p>
+        <br>
+        <a href='6384ff576b1b912573be835d.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/fcd-d641013010-c_001.jpg' class='img_varias_bicis'>
+        <h2>Bicicleta MTB Focus Jam</h2>
+        <p>
+          1 Día   - 60€ <br>
+          5 Días  - 60€ <br>
+          10 Días  - 60€ <br>
+          15 Días - 60€ <br>
+          30 Días - 60€
+        </p>
+        <br>
+        <a href='638501c66b1b912573be835e.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/dpv-c353202103-02_1001.jpg' class='img_varias_bicis'>
+        <h2>Bicicleta MTB Deporvillage GR900 29</h2>
+        <p>
+          1 Día   - 17€ <br>
+          5 Días  - 17€ <br>
+          10 Días  - 17€ <br>
+          15 Días - 17€ <br>
+          30 Días - 17€
+        </p>
+        <br>
+        <a href='638503506b1b912573be835f.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://cdn.deporvillage.com/cdn-cgi/image/f=auto,q=75,fit=contain,background=white/product/umt-2611-71_001_1.jpg' class='img_varias_bicis'>
+        <h2>Bicicleta MTB Umit 4 Motion</h2>
+        <p>
+          1 Día   - 12€ <br>
+          5 Días  - 12€ <br>
+          10 Días  - 12€ <br>
+          15 Días - 12€ <br>
+          30 Días - 12€
+        </p>
+        <br>
+        <a href='6385081c6b1b912573be8361.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://cdn.deporvillage.com/cdn-cgi/image/h=576,w=576,dpr=1,f=auto,q=75,fit=contain,background=white/product/me-51780-c_001.jpg' class='img_varias_bicis'>
+        <h2>Bicicleta MTB Merida Big Nine 300</h2>
+        <p>
+          1 Día   - 31€ <br>
+          5 Días  - 31€ <br>
+          10 Días  - 31€ <br>
+          15 Días - 31€ <br>
+          30 Días - 31€
+        </p>
+        <br>
+        <a href='638508996b1b912573be8362.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/m6191673/k$3ac858333488e0f532c39e672c446e75/sq/bicicleta-electrica-de-ciudad-ncm-c5.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta eléctrica de ciudad NCM C5</h2>
+        <p>
+          1 Día   - 56€ <br>
+          5 Días  - 56€ <br>
+          10 Días  - 56€ <br>
+          15 Días - 56€ <br>
+          30 Días - 56€
+        </p>
+        <br>
+        <a href='63850b7f6b1b912573be8363.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p2323533/k$fd94592e41e52e8240d17a17e51fe1ba/sq/bicicleta-electrica-trekking-cuadro-bajo-riverside-100-e-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta eléctrica trekking cuadro bajo Riverside 100 E azul</h2>
+        <p>
+          1 Día   - 72€ <br>
+          5 Días  - 72€ <br>
+          10 Días  - 72€ <br>
+          15 Días - 72€ <br>
+          30 Días - 72€
+        </p>
+        <br>
+        <a href='63850c2b6b1b912573be8364.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1638738/k$fd2bacecab66a5bd4a0d4a3fbd5359d6/sq/bicicleta-electrica-de-montaa-275-rockrider-ebike-st-900-gris.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Rockrider Ebike ST 900 gris</h2>
+        <p>
+          1 Día   - 100€ <br>
+          5 Días  - 100€ <br>
+          10 Días  - 100€ <br>
+          15 Días - 100€ <br>
+          30 Días - 100€
+        </p>
+        <br>
+        <a href='63850f366b1b912573be8365.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p1958112/k$a37e0dd7e3d9bbd6f926e3b6d7a91d09/sq/bicicleta-electrica-gravel-de-carbono-windee-negra.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta eléctrica gravel de carbono Windee negra</h2>
+        <p>
+          1 Día   - 100€ <br>
+          5 Días  - 100€ <br>
+          10 Días  - 100€ <br>
+          15 Días - 100€ <br>
+          30 Días - 100€
+        </p>
+        <br>
+        <a href='638510436b1b912573be8366.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/m5641940/k$9bc5d7e36c065ce82584903381b6b936/sq/bicicleta-electrica-de-montaa-ncm-moscow.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta eléctrica de montaña NCM Moscow</h2>
+        <p>
+          1 Día   - 70€ <br>
+          5 Días  - 70€ <br>
+          10 Días  - 70€ <br>
+          15 Días - 70€ <br>
+          30 Días - 70€
+        </p>
+        <br>
+        <a href='638511156b1b912573be8367.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p2288175/k$0bb7564beb0379fa4e8b9f41d727da6f/sq/bicicleta-urbana-clasica-elops-520-cuadro-bajo-28-pulgadas-6-v-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta urbana clásica Elops 520 cuadro bajo 28 pulgadas 6 V azul</h2>
+        <p>
+          1 Día   - 32€ <br>
+          5 Días  - 32€ <br>
+          10 Días  - 32€ <br>
+          15 Días - 32€ <br>
+          30 Días - 32€
+        </p>
+        <br>
+        <a href='638512916b1b912573be8368.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p2215480/k$256efddc38e0e25002047e8cbd47b22e/sq/bicicleta-urbana-cuadro-alto-elops-540-azul-petroleo.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta urbana cuadro alto Elops 540 azul petróleo</h2>
+        <p>
+          1 Día   - 55€ <br>
+          5 Días  - 55€ <br>
+          10 Días  - 55€ <br>
+          15 Días - 55€ <br>
+          30 Días - 55€
+        </p>
+        <br>
+        <a href='63852f6725096331c621b254.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/p2288260/k$9e8ec5fdb2caecee5f0cd29ff6ae03cb/sq/bicicleta-urbana-clasica-cuadro-bajo-28-pulgadas-elops-120-azul.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta urbana clásica cuadro bajo 28 pulgadas Elops 120 azul</h2>
+        <p>
+          1 Día   - 15€ <br>
+          5 Días  - 15€ <br>
+          10 Días  - 15€ <br>
+          15 Días - 15€ <br>
+          30 Días - 15€
+        </p>
+        <br>
+        <a href='6385317c25096331c621b255.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/m5419555/k$1a25a4a575387a8eef87a6174396db0a/sq/bicicleta-paseo-city-classic-26-aluminio-shimano-18v.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta Paseo City Classic 26</h2>
+        <p>
+          1 Día   - 26€ <br>
+          5 Días  - 26€ <br>
+          10 Días  - 26€ <br>
+          15 Días - 26€ <br>
+          30 Días - 26€
+        </p>
+        <br>
+        <a href='6385328525096331c621b256.html'>ALQUILAR</a>
+      </div>
+      <div class="general_una_bici">
+        <img src='https://contents.mediadecathlon.com/m5419674/k$a70f29effa74ced3f5e632bca44df671/sq/bicicleta-trekking-paseo-shimano-hybrid-28-alu-18v-susp-delant.jpg?format=auto&f=800x0' class='img_varias_bicis'>
+        <h2>Bicicleta Trekking</h2>
+        <p>
+          1 Día   - 14€ <br>
+          5 Días  - 14€ <br>
+          10 Días  - 14€ <br>
+          15 Días - 14€ <br>
+          30 Días - 14€
+        </p>
+        <br>
+        <a href='638534fa25096331c621b257.html'>ALQUILAR</a>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/presentation/crearGeneralHtml.py
+++ b/src/presentation/crearGeneralHtml.py
@@ -13,7 +13,7 @@ def generarPaginaTodasBicis():
     
     # BODY del HTMl
     general_html.write(body)
-    general_html.write('<h1 class="titulo_general"> Estas son todas las bicis que tenemos actualmente:</h1>\n')
+    general_html.write('    <h1 class="titulo_general"> Estas son todas las bicis que tenemos actualmente:</h1>\n')
     general_html.write(div_global)
     
 
@@ -21,16 +21,16 @@ def generarPaginaTodasBicis():
     i = 0
     for bici in bicis:
         general_html.write(general_unica_bici)
-        general_html.write("<img src='"+ bicis[i]["img"] +"' class='img_varias_bicis'>\n")
-        general_html.write("<h2>"+ bicis[i]["nombre"] +"</h2>\n")
-        general_html.write('<p>\n 1 Día   - ' + bicis[i]["precio"] + '€ <br>\n 5 Días  - ' + bicis[i]["precio"] + '€ <br>\n 10 Días  - ' + bicis[i]["precio"] + '€ <br>\n  15 Días - ' + bicis[i]["precio"] + '€ <br>\n  30 Días - ' + bicis[i]["precio"] + '€ </p> <br>\n')
-        general_html.write(br)
-        general_html.write("<a href='"+ bicis[i]["_id"] +".html'>ALQUILAR</a>\n")
+        general_html.write("        <img src='"+ bicis[i]["img"] +"' class='img_varias_bicis'>\n")
+        general_html.write("        <h2>"+ bicis[i]["nombre"] +"</h2>\n")
+        general_html.write('        <p>\n          1 Día   - ' + bicis[i]["precio"] + '€ <br>\n          5 Días  - ' + bicis[i]["precio"] + '€ <br>\n          10 Días  - ' + bicis[i]["precio"] + '€ <br>\n          15 Días - ' + bicis[i]["precio"] + '€ <br>\n          30 Días - ' + bicis[i]["precio"] + '€\n        </p>\n')
+        general_html.write(br_global)
+        general_html.write("        <a href='"+ bicis[i]["_id"] +".html'>ALQUILAR</a>\n")
         general_html.write(fin_div)
 
         i += 1
 
-    general_html.write(fin_div)
+    general_html.write(fin_div_general)
     general_html.write(fin_body)
     general_html.write(fin_html)
 

--- a/src/presentation/variablesHtml.py
+++ b/src/presentation/variablesHtml.py
@@ -2,34 +2,30 @@
 # Variables globales HTML en Python
 head = f'''<!Doctype html>
 <html LANG="es">
-    <head>
-        <meta charset="utf-8">
-        <meta name="description" content="Alquila la bici que mas te guste al mejor precio">
-        <meta name="author" content="Adrián López">
-        <meta name="date" content="27/11/2020">
-        <meta name="last-modified" content="04 de Diciembre de 2022">
-        <meta name="keyword" content="Bicis, Alquilar bicis, Monbike, Mallorca bicis">
-        <link rel="StyleSheet" href="style.css">
-        
-        <!-- LOGO MonBike-->
-        <link rel="shortcut icon" href="img/monbike_bici_logo.png">
+  <head>
+    <meta charset="utf-8">
+    <meta name="description" content="Alquila la bici que mas te guste al mejor precio">
+    <meta name="author" content="Adrián López">
+    <meta name="date" content="27/11/2020">
+    <meta name="last-modified" content="04 de Diciembre de 2022">
+    <meta name="keyword" content="Bicis, Alquilar bicis, Monbike, Mallorca bicis">
+    <link rel="StyleSheet" href="style.css">
+    
+    <!-- LOGO MonBike-->
+    <link rel="shortcut icon" href="img/monbike_bici_logo.png">
 
-        <!-- Titulo MonBike -->
-        <title>MonBike</title>
-    </head>\n''' 
+    <!-- Titulo MonBike -->
+    <title>MonBike</title>
+  </head>\n''' 
 
-body = "    <body>\n"
-
-
-fin_body = "    </body>\n"
-
-br = "<br>\n"
-
+body = "  <body>\n"
+fin_body = "  </body>\n"
 
 # Variables para la pagina donde aparece todas las bicis
 
-div_global = '<div class="general_bicis">\n'
-general_unica_bici = '<div class="general_una_bici">\n'
-fin_div = '</div>\n'
-
+div_global = '    <div class="general_bicis">\n'
+general_unica_bici = '      <div class="general_una_bici">\n'
+fin_div = '      </div>\n'
+fin_div_general = '    </div>\n'
+br_global = "        <br>\n"
 fin_html = "</html>"


### PR DESCRIPTION
Cuando ejecutaba el archivo "crearGeneralHtml.py" para que nos crease el archivo "general.html" y mirabas el código HTML de dicho archivo, estaba todo desordenado dado que no estaban bien indicados los espacios entre ellos.